### PR TITLE
migrate to py-cord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres (somewhat) to [Semantic Versioning](https://semver.org/
 
 
 ## [Unreleased]
+## Added
+- Config option to automatically strip spaces after the prefix. Update your configs.
+- First support for discord.py logging output.
+## Changed
+- Migrated to Pycord.
 
 
 ## [1.4.0] - 2021-01-18

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ Released under the terms of the MIT License.
 See LICENSE for the full text of the license.
 """
 
+import logging
 
 import discord
 from discord.ext import commands, tasks
@@ -19,6 +20,8 @@ import info
 import data.keys as keys
 import data.options as opt
 
+
+logging.basicConfig(level=logging.WARNING)
 
 # --- Vars ---
 
@@ -33,14 +36,14 @@ intents.members = True
 intents.messages = True
 intents.dm_messages = True
 intents.presences = True
+intents.message_content = True
 
 # Setting up the member cache
 member_cache_flags = discord.MemberCacheFlags.none()
 member_cache_flags.joined = True
-member_cache_flags.online = True
 
 bot = commands.Bot(command_prefix=opt.command_prefix, intents=intents, member_cache_flags=member_cache_flags,
-                   chunk_guilds_at_startup=True, case_insensitive=True)
+                   chunk_guilds_at_startup=True, case_insensitive=True, strip_after_prefix=True)
 
 
 # --- Commands ---

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ member_cache_flags = discord.MemberCacheFlags.none()
 member_cache_flags.joined = True
 
 bot = commands.Bot(command_prefix=opt.command_prefix, intents=intents, member_cache_flags=member_cache_flags,
-                   chunk_guilds_at_startup=True, case_insensitive=True, strip_after_prefix=True)
+                   chunk_guilds_at_startup=True, case_insensitive=True, strip_after_prefix=opt.strip_after_prefix)
 
 
 # --- Commands ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-discord.py~=1.6.0
+py-cord[speed]~=2.3.2
+aiohttp[speedups]

--- a/templates/data/options.py
+++ b/templates/data/options.py
@@ -18,6 +18,10 @@ Settings and options for the bot.
 # ie: `["?", "!", "pls "]`
 command_prefix = ["mb?", "Mb?"]
 
+# Strip whitespace between prefix and command automatically
+# https://docs.pycord.dev/en/stable/ext/commands/api.html#discord.ext.commands.Bot.strip_after_prefix
+strip_after_prefix = True
+
 # The prefix to use for display purposes (ex: status message).
 display_prefix = "mb?"
 

--- a/templates/data/options.py
+++ b/templates/data/options.py
@@ -16,7 +16,7 @@ Settings and options for the bot.
 
 # The prefix for the bot (str). Define a list of stings for multiple prefixes.
 # ie: `["?", "!", "pls "]`
-command_prefix = ["mb? ", "mb?", "Mb? ", "Mb?"]
+command_prefix = ["mb?", "Mb?"]
 
 # The prefix to use for display purposes (ex: status message).
 display_prefix = "mb?"


### PR DESCRIPTION
- aiohttp in requirements.txt can be removed when Pycord-Development/pycord#1830 is merged
- added logging to see errors from py-cord
